### PR TITLE
Set path name to be based on timestamp in messages

### DIFF
--- a/firehose.go
+++ b/firehose.go
@@ -78,7 +78,7 @@ func (e LeaderFileExists) Error() string {
 	return "Leader file already exists"
 }
 
-type indexFile struct {
+type IndexFile struct {
 	Name         string `json:"name"`
 	MinTimestamp int64  `json:"min_timestamp"`
 	MaxTimestamp int64  `json:"max_timestamp"`
@@ -342,7 +342,7 @@ func (fp *Firehose) writeIndex(
 	minTimestamp time.Time,
 	maxTimestamp time.Time,
 ) error {
-	indexEntry, err := json.Marshal(indexFile{
+	indexEntry, err := json.Marshal(IndexFile{
 		Name:         name,
 		MinTimestamp: minTimestamp.Unix(),
 		MaxTimestamp: maxTimestamp.Unix(),

--- a/firehose_test.go
+++ b/firehose_test.go
@@ -704,7 +704,8 @@ outer:
 
 			// Check each line of the index file
 			actual0 := firehose.IndexFile{}
-			json.Unmarshal([]byte(lines[0]), &actual0)
+			err = json.Unmarshal([]byte(lines[0]), &actual0)
+			s.Require().Nil(err)
 			assert.Equal(s.T(), actual0, firehose.IndexFile{
 				Name:         fmt.Sprintf("%d_%s", msg2.Metadata.Timestamp.Unix(), msg2.ID),
 				MinTimestamp: msg1.Metadata.Timestamp.Unix(),
@@ -712,7 +713,8 @@ outer:
 			})
 
 			actual1 := firehose.IndexFile{}
-			json.Unmarshal([]byte(lines[1]), &actual1)
+			err = json.Unmarshal([]byte(lines[1]), &actual1)
+			s.Require().Nil(err)
 			assert.Equal(s.T(), actual1, firehose.IndexFile{
 				Name:         fmt.Sprintf("%d_%s", msg3.Metadata.Timestamp.Unix(), msg3.ID),
 				MinTimestamp: msg3.Metadata.Timestamp.Unix(),

--- a/firehose_test.go
+++ b/firehose_test.go
@@ -558,20 +558,17 @@ func (s *GcpTestSuite) RunFirehoseLeaderIntegration() {
 
 	// Set message timestamps to be 2022/10/15 (a day before the time we set above)
 	userId := "C_1234567890123456"
-	msg1Time := time.Date(2022, time.Month(10), 15, 0, 0, 0, 0, time.UTC)
-	msg1 := s.userCreatedMessage(f, userId, "bar", msg1Time)
+	msg1 := s.userCreatedMessage(f, userId, "bar", time.Date(2022, time.Month(10), 15, 0, 0, 0, 0, time.UTC))
 	expected1 := s.serialize(f, msg1)
 
 	// Next message sent 10 seconds later
 	userId2 := "C_9012345678901234"
-	msg2Time := time.Date(2022, time.Month(10), 15, 0, 0, 10, 0, time.UTC)
-	msg2 := s.userCreatedMessage(f, userId2, "bar2", msg2Time)
+	msg2 := s.userCreatedMessage(f, userId2, "bar2", time.Date(2022, time.Month(10), 15, 0, 0, 10, 0, time.UTC))
 	expected2 := s.serialize(f, msg2)
 
 	// Next message sent another 10 seconds later
 	userId3 := "C_0123456789012345"
-	msg3Time := time.Date(2022, time.Month(10), 15, 0, 0, 20, 0, time.UTC)
-	msg3 := s.userCreatedMessage(f, userId3, "bar3", msg3Time)
+	msg3 := s.userCreatedMessage(f, userId3, "bar3", time.Date(2022, time.Month(10), 15, 0, 0, 20, 0, time.UTC))
 	expected3 := s.serialize(f, msg3)
 
 	s.server.CreateObject(fakestorage.Object{
@@ -706,16 +703,16 @@ outer:
 			json.Unmarshal([]byte(lines[0]), &actual0)
 			assert.Equal(s.T(), actual0, indexFile{
 				Name:         "1665878400",
-				MinTimestamp: msg1Time.Unix(),
-				MaxTimestamp: msg2Time.Unix(),
+				MinTimestamp: msg1.Metadata.Timestamp.Unix(),
+				MaxTimestamp: msg2.Metadata.Timestamp.Unix(),
 			})
 
 			actual1 := indexFile{}
 			json.Unmarshal([]byte(lines[1]), &actual1)
 			assert.Equal(s.T(), actual1, indexFile{
 				Name:         "1665879000",
-				MinTimestamp: msg3Time.Unix(),
-				MaxTimestamp: msg3Time.Unix(),
+				MinTimestamp: msg3.Metadata.Timestamp.Unix(),
+				MaxTimestamp: msg3.Metadata.Timestamp.Unix(),
 			})
 
 			assert.Equal(s.T(), len(lines), 3) // 3, because of the empty line at the end

--- a/firehose_test.go
+++ b/firehose_test.go
@@ -703,17 +703,17 @@ outer:
 			lines := strings.Split(string(res[:]), "\n")
 
 			// Check each line of the index file
-			actual0 := indexFile{}
+			actual0 := firehose.IndexFile{}
 			json.Unmarshal([]byte(lines[0]), &actual0)
-			assert.Equal(s.T(), actual0, indexFile{
+			assert.Equal(s.T(), actual0, firehose.IndexFile{
 				Name:         fmt.Sprintf("%d_%s", msg2.Metadata.Timestamp.Unix(), msg2.ID),
 				MinTimestamp: msg1.Metadata.Timestamp.Unix(),
 				MaxTimestamp: msg2.Metadata.Timestamp.Unix(),
 			})
 
-			actual1 := indexFile{}
+			actual1 := firehose.IndexFile{}
 			json.Unmarshal([]byte(lines[1]), &actual1)
-			assert.Equal(s.T(), actual1, indexFile{
+			assert.Equal(s.T(), actual1, firehose.IndexFile{
 				Name:         fmt.Sprintf("%d_%s", msg3.Metadata.Timestamp.Unix(), msg3.ID),
 				MinTimestamp: msg3.Metadata.Timestamp.Unix(),
 				MaxTimestamp: msg3.Metadata.Timestamp.Unix(),
@@ -725,12 +725,6 @@ outer:
 	assert.Equal(s.T(), 1, len(userCreatedObjs))
 	assert.True(s.T(), foundIndex)
 	cancel()
-}
-
-type indexFile struct {
-	Name         string `json:"name"`
-	MinTimestamp int64  `json:"min_timestamp"`
-	MaxTimestamp int64  `json:"max_timestamp"`
 }
 
 func (s *GcpTestSuite) TestIsLeaderFileBadFormat() {


### PR DESCRIPTION
Currently, the path to the file in the output bucket is based on when the firehose leader creates the file ("now"), rather than the timestamp of the messages themselves.

This can cause issues if the consumers are lagging far behind. E.g., if a message was sent on January 1st, we would expect to see the messages at the path `2023/1/1/`. Normally this is fine, but if the consumer is backlogged and we don't process the messages until January 3rd, those messages will end up in `2023/1/3/`, and users will be unable to find it.

This PR updates the path of the file to correspond to the max timestamp within the batch of messages, to prevent the above issue. The file name includes both the timestamp and ID of the latest message in the batch, to ensure that it's unique (it's possible that we could receive multiple messages with the same timestamp across scrapes).